### PR TITLE
Fix variable typo

### DIFF
--- a/templates/db.js
+++ b/templates/db.js
@@ -5,4 +5,4 @@ const supabase = createClient(
   import.meta.env.VITE_SUPABASE_ANON_KEY
 )
 
-export default suspabase
+export default supabase


### PR DESCRIPTION
There was no variable named `suspabase` so I asumed you wanted to type `supabase`.